### PR TITLE
Fix "github.com//repo_name"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ extra:
         name: Spacebar # Tip: use {{ project_name.lower() }} to get the project name in lowercase.
         domain: spacebar.chat
     repositories:
-        base_url: https://github.com/
+        base_url: https://github.com
         server: spacebarchat/server
         client: spacebarchat/client
         missing_routes: spacebarchat/missing-routes


### PR DESCRIPTION
i did an oopsie.
if you view the current deployment, for example the page https://docs.spacebar.chat/setup/clients/#setupbuilding and take a look at the git clone command, you'll see that it says "github.com//". this pr fixes that by removing "/" from the base_url macro.

oops :3 