### PR TITLE
Change setup instructions

### DIFF
--- a/docs/setup/clients/index.md
+++ b/docs/setup/clients/index.md
@@ -4,7 +4,7 @@
 
 !!! warning "Windows support is currently broken."
 
-The official {{ project.name }} client is currently being developed at [this repository]({{ repositories.base_url }}/{{ repositories.client }}/tree/dev/bare-rewrite).
+The official {{ project.name }} client is currently being developed at [this repository]({{ repositories.base_url }}/{{ repositories.client }}).
 
 ## Official host
 

--- a/docs/setup/clients/index.md
+++ b/docs/setup/clients/index.md
@@ -14,13 +14,13 @@ or you can use it to connect to your own by editing your local storage to includ
 
 ```json
 {
- "api": "https://staging.{{ project.domain }}/api/v9",
- "cdn": "https://cdn.staging.{{ project.domain }}",
- "gateway": "wss://gateway.staging.{{ project.domain }}",
- "invite": "https://staging.{{ project.domain }}/invite",
- "template": "https://staging.{{ project.domain }}/template",
- "gift": "https://staging.{{ project.domain }}/gift",
- "scheduledEvent": "https://staging.{{ project.domain }}/events"
+	"api": "https://staging.{{ project.domain }}/api/v9",
+	"cdn": "https://cdn.staging.{{ project.domain }}",
+	"gateway": "wss://gateway.staging.{{ project.domain }}",
+	"invite": "https://staging.{{ project.domain }}/invite",
+	"template": "https://staging.{{ project.domain }}/template",
+	"gift": "https://staging.{{ project.domain }}/gift",
+	"scheduledEvent": "https://staging.{{ project.domain }}/events"
 }
 ```
 
@@ -31,9 +31,9 @@ Replace the above endpoints with your own. If your domain name is `https://whate
 
 ### Dependencies
 
-- [Git](https://git-scm.com/)
-- [NodeJS](https://nodejs.org). Version 16+
-- [yarn](https://yarnpkg.com/) (preferred) or npm
+-   [Git](https://git-scm.com/)
+-   [NodeJS](https://nodejs.org). Version 16+
+-   [yarn](https://yarnpkg.com/) (preferred) or npm
 
 In your terminal:
 
@@ -86,13 +86,13 @@ Files will be built to `web-build`
 
 To contribute:
 
-- [Fork the repository]({{ repositories.base_url }}/{{ repositories.client }}/fork)
-- Run the building instructions.
-- Commit & Push.
-- Pull Request & Done!
+-   [Fork the repository]({{ repositories.base_url }}/{{ repositories.client }}/fork)
+-   Run the building instructions.
+-   Commit & Push.
+-   Pull Request & Done!
 
 ### What can I contribute?
 
-- "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
-- Implementing other things like voice/video is fine too, though
-- [This]({{ repositories.base_url }}/{{ repositories.client }}/issues/21) is a good starting point and lists the core features that are still missing from the client.
+-   "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
+-   Implementing other things like voice/video is fine too, though
+-   [This]({{ repositories.base_url }}/{{ repositories.client }}/issues/21) is a good starting point and lists the core features that are still missing from the client.

--- a/docs/setup/clients/index.md
+++ b/docs/setup/clients/index.md
@@ -14,13 +14,13 @@ or you can use it to connect to your own by editing your local storage to includ
 
 ```json
 {
-	"api": "https://staging.{{ project.domain }}/api/v9",
-	"cdn": "https://cdn.staging.{{ project.domain }}",
-	"gateway": "wss://gateway.staging.{{ project.domain }}",
-	"invite": "https://staging.{{ project.domain }}/invite",
-	"template": "https://staging.{{ project.domain }}/template",
-	"gift": "https://staging.{{ project.domain }}/gift",
-	"scheduledEvent": "https://staging.{{ project.domain }}/events"
+ "api": "https://staging.{{ project.domain }}/api/v9",
+ "cdn": "https://cdn.staging.{{ project.domain }}",
+ "gateway": "wss://gateway.staging.{{ project.domain }}",
+ "invite": "https://staging.{{ project.domain }}/invite",
+ "template": "https://staging.{{ project.domain }}/template",
+ "gift": "https://staging.{{ project.domain }}/gift",
+ "scheduledEvent": "https://staging.{{ project.domain }}/events"
 }
 ```
 
@@ -31,9 +31,9 @@ Replace the above endpoints with your own. If your domain name is `https://whate
 
 ### Dependencies
 
--   [Git](https://git-scm.com/)
--   [NodeJS](https://nodejs.org). Version 16+
--   [yarn](https://yarnpkg.com/) (preferred) or npm
+- [Git](https://git-scm.com/)
+- [NodeJS](https://nodejs.org). Version 16+
+- [yarn](https://yarnpkg.com/) (preferred) or npm
 
 In your terminal:
 
@@ -42,7 +42,7 @@ In your terminal:
 git clone {{ repositories.base_url }}/{{ repositories.client }}.git
 
 # Enter the cloned directory, switch branches to the one, which is actually being developed
-cd client; git switch dev/bare-rewrite
+cd client
 
 # Install dependencies
 yarn install
@@ -86,13 +86,13 @@ Files will be built to `web-build`
 
 To contribute:
 
--   [Fork the repository]({{ repositories.base_url }}/{{ repositories.client }}/fork)
--   Run the building instructions.
--   Commit & Push.
--   Pull Request & Done!
+- [Fork the repository]({{ repositories.base_url }}/{{ repositories.client }}/fork)
+- Run the building instructions.
+- Commit & Push.
+- Pull Request & Done!
 
 ### What can I contribute?
 
--   "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
--   Implementing other things like voice/video is fine too, though
--   [This]({{ repositories.base_url }}/{{ repositories.client }}/issues/21) is a good starting point and lists the core features that are still missing from the client.
+- "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
+- Implementing other things like voice/video is fine too, though
+- [This]({{ repositories.base_url }}/{{ repositories.client }}/issues/21) is a good starting point and lists the core features that are still missing from the client.


### PR DESCRIPTION
Previously, branch switching was basically required to use the up-to-date version of the client. Since the React Native client has been made the master branch, this is no longer needed, and the branch reference in the old docs has been made outdated.