### PR TITLE
Change minimum node version to 18 and Change Python 3 from undefined to 3.10 or later.

### DIFF
--- a/docs/setup/server/index.md
+++ b/docs/setup/server/index.md
@@ -14,8 +14,8 @@ We do not recommend using Windows to run {{ project.name }}.
 ## Dependencies
 
 -   [Git](https://git-scm.com/)
--   [NodeJS](https://nodejs.org). Version 16+ (for `npm`, `node` commands)
--   [Python](https://www.python.org/). Version 3+. Make sure this is executable via `python` in your terminal.  
+-   [NodeJS](https://nodejs.org). Version 18+ (for `npm`, `node` commands)
+-   [Python](https://www.python.org/). Version 3.10 or later. Make sure this is executable via `python` in your terminal.  
      (See: `python-is-python3` package)
 -   On Linux: `gcc`/`g++`. Packaged with `build-essential` on Debian/Ubuntu and `base-devel` on Arch.
 -   On Windows: [Visual Studio](https://visualstudio.microsoft.com/) (**NOT** VSCode) with the `Desktop development with C++` package.


### PR DESCRIPTION
Node 16 is going EOL in September. Lets migrate to 18 now to give users time to update. Node 16 is going EOL earlier than planned due to OpenSSL 1.1.1 going EOL. 