### PR TITLE
Add SSL/TLS certificate requirement to "endorsed instance" requirements

### DIFF
--- a/docs/contributing/instances.md
+++ b/docs/contributing/instances.md
@@ -13,6 +13,7 @@ Your instance:
 6. Must have a valid and monitored [`general_correspondenceEmail` config](/setup/server/configuration) set.
 7. Must not have default [rights](/setup/server/security/rights) that include operator or other administrative rights.
 8. Enable [Imagor](/setup/server/configuration/imagor), as no image proxy allows attackers to learn user IP addresses.
+9. Have a valid SSL/TLS certificate for the API, Gateway and CDN endpoints. 
 
 We recommend (not required) that you:
 

--- a/docs/contributing/instances.md
+++ b/docs/contributing/instances.md
@@ -13,7 +13,7 @@ Your instance:
 6. Must have a valid and monitored [`general_correspondenceEmail` config](/setup/server/configuration) set.
 7. Must not have default [rights](/setup/server/security/rights) that include operator or other administrative rights.
 8. Enable [Imagor](/setup/server/configuration/imagor), as no image proxy allows attackers to learn user IP addresses.
-9. Have a valid SSL/TLS certificate for the API, Gateway and CDN endpoints. 
+9. Have a valid SSL/TLS certificate for all endpoints.
 
 We recommend (not required) that you:
 


### PR DESCRIPTION
This is pretty self-explanatory. I believe that an endorsed instance should have an SSL/TLS certificate for the main client endpoints. I'm happy to elaborate if required