### PR TITLE
Replace "media.whatever.com" with "media.example.com" in imagor page

### DIFF
--- a/docs/setup/server/configuration/imagor.md
+++ b/docs/setup/server/configuration/imagor.md
@@ -41,14 +41,14 @@ location /media/ {
 ```
 
 Along with any additional config you already have, of course.
-Alternative (and perhaps the better choice) would be to create a new domain, say `media.whatever.com` specifically for Imagor.
+Alternative (and perhaps the better choice) would be to create a new domain, say `media.example.com` specifically for Imagor.
 
-??? "Example config for `media.whatever.com` site"
+??? "Example config for `media.example.com` site"
 
     ```nginx
     server {
      # Change the server_name to reflect your true domain
-        server_name media.whatever.com;
+        server_name media.example.com;
 
         add_header Last-Modified $date_gmt;
         proxy_set_header Host $host;


### PR DESCRIPTION
On the [Imagor](https://docs.spacebar.chat/setup/server/configuration/imagor/) docs page `media.whatever.com` is used as a placeholder domain. However, `whatever.com` is privately owned and currently redirects to subscribe to some YouTuber's channel. 

This PR replaces `media.whatever.com` with `media.example.com` because `example.com` is a domain reserved by the Internet Assigned Numbers Authority (IANA) and is allowed to be used "as illustrative examples in documents without prior coordination with [the IANA]" [(source)](https://www.iana.org/help/example-domains).