### PR TITLE
Add NodeSource note for Ubuntu and Debian based systems

### DIFF
--- a/docs/setup/server/index.md
+++ b/docs/setup/server/index.md
@@ -15,10 +15,10 @@ We do not recommend using Windows to run {{ project.name }}.
 
 -   [Git](https://git-scm.com/)
 -   [NodeJS](https://nodejs.org). Version 18+ (for `npm`, `node` commands)
+     (NOTE: Ubuntu or Debian based systems often ship with an outdated version of NodeJS, so you can use [NodeSource](https://github.com/nodesource/distributions) to install a newer version)
 -   [Python](https://www.python.org/). Version 3.10 or later. Make sure this is executable via `python` in your terminal.  
      (See: `python-is-python3` package)
 -   On Linux: `gcc`/`g++`. Packaged with `build-essential` on Debian/Ubuntu and `base-devel` on Arch.
-     (NOTE: Ubuntu or Debian based systems often ship with outdated versions, so we recommend using NodeJS from [NodeSource](https://github.com/nodesource/distributions))
 -   On Windows: [Visual Studio](https://visualstudio.microsoft.com/) (**NOT** VSCode) with the `Desktop development with C++` package.
     You do not need the full Visual Studio install, the build tools are fine.
 

--- a/docs/setup/server/index.md
+++ b/docs/setup/server/index.md
@@ -18,6 +18,7 @@ We do not recommend using Windows to run {{ project.name }}.
 -   [Python](https://www.python.org/). Version 3.10 or later. Make sure this is executable via `python` in your terminal.  
      (See: `python-is-python3` package)
 -   On Linux: `gcc`/`g++`. Packaged with `build-essential` on Debian/Ubuntu and `base-devel` on Arch.
+     (NOTE: Ubuntu or Debian based systems can use NodeJS from [NodeSource](https://github.com/nodesource/distributions))
 -   On Windows: [Visual Studio](https://visualstudio.microsoft.com/) (**NOT** VSCode) with the `Desktop development with C++` package.
     You do not need the full Visual Studio install, the build tools are fine.
 

--- a/docs/setup/server/index.md
+++ b/docs/setup/server/index.md
@@ -18,7 +18,7 @@ We do not recommend using Windows to run {{ project.name }}.
 -   [Python](https://www.python.org/). Version 3.10 or later. Make sure this is executable via `python` in your terminal.  
      (See: `python-is-python3` package)
 -   On Linux: `gcc`/`g++`. Packaged with `build-essential` on Debian/Ubuntu and `base-devel` on Arch.
-     (NOTE: Ubuntu or Debian based systems can use NodeJS from [NodeSource](https://github.com/nodesource/distributions))
+     (NOTE: Ubuntu or Debian based systems often ship with outdated versions, so we recommend using NodeJS from [NodeSource](https://github.com/nodesource/distributions))
 -   On Windows: [Visual Studio](https://visualstudio.microsoft.com/) (**NOT** VSCode) with the `Desktop development with C++` package.
     You do not need the full Visual Studio install, the build tools are fine.
 

--- a/docs/setup/server/index.md
+++ b/docs/setup/server/index.md
@@ -15,7 +15,7 @@ We do not recommend using Windows to run {{ project.name }}.
 
 -   [Git](https://git-scm.com/)
 -   [NodeJS](https://nodejs.org). Version 18+ (for `npm`, `node` commands)
-     (NOTE: Ubuntu or Debian based systems often ship with an outdated version of NodeJS, so you can use [NodeSource](https://github.com/nodesource/distributions) to install a newer version)
+     (NOTE: Ubuntu and Debian based systems often ship with an outdated version of NodeJS, so you can use [NodeSource](https://github.com/nodesource/distributions) to install a newer version)
 -   [Python](https://www.python.org/). Version 3.10 or later. Make sure this is executable via `python` in your terminal.  
      (See: `python-is-python3` package)
 -   On Linux: `gcc`/`g++`. Packaged with `build-essential` on Debian/Ubuntu and `base-devel` on Arch.


### PR DESCRIPTION
Many People use Ubuntu and Debian Server distributions, so something like this would be really good to include in the setup.