### PR TITLE
CNAME file to not accidentally override GitHub Pages Domain Settings

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.spacebar.chat


### PR DESCRIPTION
Normally, if you push to a gh-pages enabled mkdocs material repo which does not have a CNAME file, the custom domain set in repository settings (docs.spacebar.chat, in this case) gets overridden after a successful page deploy, which means you usually have to re-add the custom domain in settings, which is annoying.

Adding a CNAME file in the root of the `docs/` dir of an mkdocs-material repo solves this. I am not sure if this repository even has this problem, though.