### PR TITLE
Corrected well-known link.

### DIFF
--- a/docs/setup/bots/index.md
+++ b/docs/setup/bots/index.md
@@ -11,7 +11,7 @@ Below are some popular libraries for connecting bots to a {{ project.name }} ins
 Make sure to replace `api.{{ project.domain }}` and `cdn.{{ project.domain }}`
 with the appropriate URLs of the instance you want to connect to.
 
-You can get them from a client or from the [well-known](server/wellknown) instance endpoint.
+You can get them from a client or from the [well-known](../server/wellknown) instance endpoint.
 
 ### Discord.js
 


### PR DESCRIPTION
Corrected well-known link in the "/setup/bots/" page. Now points to "/setup/server/wellknown/" instead of non existing "/setup/bots/server/wellknown"