### PR TITLE
Add Eris example code to bots docs

### DIFF
--- a/docs/setup/bots/index.md
+++ b/docs/setup/bots/index.md
@@ -36,6 +36,28 @@ const client = new Client({
 client.login("your token here");
 ```
 
+### Eris
+
+```js
+const bot = new Eris("your token here", {
+    intents: [
+        "guildMessages"
+    ],
+    rest: {
+    domain: "api.old.server.spacebar.chat",
+    baseURL: "/api/v9"
+    },
+    ws: {
+    headers: {
+    'User-Agent': 'eris',
+    }
+  },
+});
+
+bot.connect();
+```
+
+
 ### discord.py
 
 ```py


### PR DESCRIPTION
Working Eris code to use with Spacebar. The only problem now is fact of strictly comparing the Content-Type header ([reported](https://github.com/abalabahaha/eris/issues/1605))